### PR TITLE
Position Info Support

### DIFF
--- a/MathPort/ActionItem.lean
+++ b/MathPort/ActionItem.lean
@@ -70,6 +70,7 @@ inductive ActionItem : Type
 | «mixfix»       : MixfixKind → Name → Nat → String → ActionItem
 | «export»       : ExportDecl → ActionItem
 | «projection»   : ProjectionInfo → ActionItem
+| «position»     : (name : Name) → (line col : Nat) → ActionItem
 
 def ActionItem.toDecl : ActionItem → Name
   | ActionItem.decl d =>
@@ -84,6 +85,7 @@ def ActionItem.toDecl : ActionItem → Name
   | ActionItem.reducibility n _   => n
   | ActionItem.mixfix _ n _ _     => n
   | ActionItem.export _           => `inExport
-  | ActionItem.projection p        => p.projName
+  | ActionItem.projection p       => p.projName
+  | ActionItem.position n _ _     => n
 
 end MathPort

--- a/MathPort/ParseExport.lean
+++ b/MathPort/ParseExport.lean
@@ -157,7 +157,7 @@ def processLine (line : String) : PortM (List ActionItem) := do
       | ["#PRIVATE", pretty, real]               => pure [ActionItem.private (← str2name pretty) (← str2name real)]
       | ["#PROTECTED", n]                        => pure [ActionItem.protected (← str2name n)]
 
-      | ("#POS_INFO" :: _)                       => pure []
+      | ["#POS_INFO", n, line, col]              => pure [ActionItem.position (← str2name n) (← parseNat line) (← parseNat col)]
 
       -- TODO: look at the 'deleted' bit
       | ("#ATTR" :: a :: p :: n :: _ :: rest)    => do

--- a/MathPort/ProcessActionItem.lean
+++ b/MathPort/ProcessActionItem.lean
@@ -220,7 +220,6 @@ def processActionItem (actionItem : ActionItem) : PortM Unit := do
 
     | Declaration.defnDecl defn => do
       let name := f defn.name
-      println! "[DEF] {name}"
       let type ← translate defn.type
 
       if s.ignored.contains defn.name then return ()

--- a/MathPort/ProcessActionItem.lean
+++ b/MathPort/ProcessActionItem.lean
@@ -167,6 +167,19 @@ def processActionItem (actionItem : ActionItem) : PortM Unit := do
     -- setEnv $ addProtected (← getEnv) (f n)
     pure ()
 
+  | ActionItem.position n line col => do
+      let n ← f n
+      let range ← DeclarationRanges.mk
+            { pos := { line := line, column := col }, 
+              charUtf16 := col, 
+              endPos := { line := line, column := col }, 
+              endCharUtf16 := col }
+            { pos := { line := line, column := col },
+              charUtf16 := col,
+              endPos := { line := line, column := col },
+              endCharUtf16 := col} 
+      Lean.addDeclarationRanges n range
+
   | ActionItem.decl d => do
     match d with
     | Declaration.axiomDecl ax => do
@@ -207,6 +220,7 @@ def processActionItem (actionItem : ActionItem) : PortM Unit := do
 
     | Declaration.defnDecl defn => do
       let name := f defn.name
+      println! "[DEF] {name}"
       let type ← translate defn.type
 
       if s.ignored.contains defn.name then return ()


### PR DESCRIPTION
I have added support for `#POS_INFO` by adding the corresponding `DeclarationRanges` (with all fields filled with the only position given by the `#POS_INFO`).

I believe this can be useful if we want to create source files:
- to print the declarations in the right order
- and to delete auto-generated declarations like `._proof_1`, by using the fact that they all share the same position info.